### PR TITLE
Add missing Aspect Ratio query parameter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ export type ImgixClientHints = Partial<Record<'width' | 'dpr' | 'saveData', bool
 
 // https://docs.imgix.com/apis/url
 export type ImgixUrlQueryParams = {
+    ar?: string;
     auto?: ImgixAuto;
     q?: number;
     h?: number;
@@ -73,6 +74,15 @@ const serializeImgixUrlQueryParamListValue = pipe(
 
 const mapToSerializedListValueIfDefined = mapValueIfDefined(serializeImgixUrlQueryParamListValue);
 
+const ratioRegExp = /^\d+(\.\d{2})?:\d+(\.\d{2})?$/;
+
+const validateRatio = (ratio: string | undefined): string | undefined => {
+    if (typeof ratio === 'string' && !ratioRegExp.test(ratio)) {
+        throw Error('Invalid ratio');
+    }
+    return ratio;
+};
+
 // Note: if/when this PR is merged, this type will be available via the Node types.
 // https://github.com/DefinitelyTyped/DefinitelyTyped/pull/33997
 type ParsedUrlQueryInput = { [key: string]: unknown };
@@ -80,6 +90,7 @@ type ParsedUrlQueryInput = { [key: string]: unknown };
 const serializeImgixUrlQueryParamValues = (query: ImgixUrlQueryParams): ParsedUrlQueryInput =>
     pipe(
         (): Record<keyof ImgixUrlQueryParams, string | number | undefined> => ({
+            ar: validateRatio(query.ar),
             dpr: query.dpr,
             auto: mapToSerializedListValueIfDefined(query.auto),
             fit: query.fit,

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,7 +74,7 @@ const serializeImgixUrlQueryParamListValue = pipe(
 
 const mapToSerializedListValueIfDefined = mapValueIfDefined(serializeImgixUrlQueryParamListValue);
 
-const ratioRegExp = /^\d+(\.\d{2})?:\d+(\.\d{2})?$/;
+const ratioRegExp = /^\d+(\.\d+)?:\d+(\.\d+)?$/;
 
 const validateRatio = (ratio: string | undefined): string | undefined => {
     if (typeof ratio === 'string' && !ratioRegExp.test(ratio)) {

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -15,7 +15,7 @@ assert.strictEqual(
 
 const invalidRatios = ['foo', '1:', 'foo:1', '1:foo'];
 
-const validRatios = ['1:1', '1.91:1', '1.91:1.28'];
+const validRatios = ['1:1', '1.91:1', '1.91:1.28', '1:1.28546'];
 
 assert.strictEqual(
     buildImgixUrl(baseUrl)({

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -1,8 +1,10 @@
 import * as assert from 'assert';
 import { buildImgixUrl } from './index';
 
+const baseUrl = 'https://foo.com';
+
 assert.strictEqual(
-    buildImgixUrl('https://foo.com')({
+    buildImgixUrl(baseUrl)({
         auto: {
             format: true,
         },
@@ -10,3 +12,30 @@ assert.strictEqual(
     }),
     'https://foo.com/?auto=format&w=300',
 );
+
+const invalidRatios = ['foo', '1:', 'foo:1', '1:foo'];
+
+const validRatios = ['1:1', '1.91:1', '1.91:1.28'];
+
+assert.strictEqual(
+    buildImgixUrl(baseUrl)({
+        ar: '1:1',
+    }),
+    'https://foo.com/?ar=1%3A1',
+);
+
+invalidRatios.forEach(ratio => {
+    assert.throws(() =>
+        buildImgixUrl(baseUrl)({
+            ar: ratio,
+        }),
+    );
+});
+
+validRatios.forEach(ratio => {
+    assert.doesNotThrow(() =>
+        buildImgixUrl(baseUrl)({
+            ar: ratio,
+        }),
+    );
+});


### PR DESCRIPTION
Adds [Aspect Ratio](https://docs.imgix.com/apis/url/size/ar) to the `ImgixUrlQueryParams` type.

Adds validation of this parameter to ensure that a proper aspect ratio string is passed.